### PR TITLE
Fixes `add()` without a name

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ console.log('')
 function add(bench) {
   exports.store.push(bench)
 
+  var id = bench.id;
   var len = (bench.name || (Number.isNaN(id) ? id : '<Test #' + id + '>')).length
   name_maxlen = len > name_maxlen ? len : name_maxlen
   var ops = bench.hz.toFixed(bench.hz < 100 ? 2 : 0)

--- a/test.js
+++ b/test.js
@@ -37,6 +37,9 @@ suite.add('current', function() {
 .add('random blaaaah', function() {
   return ~getSlowRandom() ? false: true
 })
+.add(function() {
+  return ~getRandom() ? false: true
+})
 .on('cycle', function(event) {
   benchmarks.add(event.target)
 })


### PR DESCRIPTION
Here's a fix for undefined `id` variable. Also, please release `1.0.0`, i think this is stable enough :)

If you need help housekeeping this, please add me on git and npm and i'll happily release this (as I do for many other modules). 

Cheers!
